### PR TITLE
Rails tutorial 11章 11.2.2送信メールのプレビューでのエラー

### DIFF
--- a/app/assets/javascripts/account_activations.coffee
+++ b/app/assets/javascripts/account_activations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/account_activations.scss
+++ b/app/assets/stylesheets/account_activations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the AccountActivations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,0 +1,2 @@
+class AccountActivationsController < ApplicationController
+end

--- a/app/helpers/account_activations_helper.rb
+++ b/app/helpers/account_activations_helper.rb
@@ -1,0 +1,2 @@
+module AccountActivationsHelper
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: "noreply@example.com"
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,22 @@
+class UserMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.account_activation.subject
+  #
+  def account_activation(user)
+    @user = user
+    mail to: user.email, subject: "Account activation"
+  end
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.password_reset.subject
+  #
+  def password_reset
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token
-  before_save { email.downcase! }
+  attr_accessor :remember_token, :activation_token
+  before_save   :downcase_email
+  before_create :create_activation_digest
   validates :name, presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
   validates :email, presence: true, length: { maximum: 255 }, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false }
@@ -34,4 +35,17 @@ class User < ApplicationRecord
   def forget
     update_attribute(:remember_digest, nil)
   end
+
+  private
+
+    # メールアドレスをすべて小文字にする
+    def downcase_email
+      email.downcase!
+    end
+
+    # 有効化トークンとダイジェストを作成および代入する
+    def create_activation_digest
+      self.activation_token  = User.new_token
+      self.activation_digest = User.digest(activation_token)
+    end
 end

--- a/app/views/user_mailer/account_activation.html.slim
+++ b/app/views/user_mailer/account_activation.html.slim
@@ -1,0 +1,8 @@
+h1 Sample App
+
+p Hi = @user.name ,
+
+Welcome to the Sample App! Click on the link below to activate your account:
+
+= link_to "Activate", edit_account_activation_url(@user.activation_token,
+                                                    email: @user.email)

--- a/app/views/user_mailer/account_activation.text.slim
+++ b/app/views/user_mailer/account_activation.text.slim
@@ -1,0 +1,3 @@
+Hi = @user.name
+Welcome to the Sample App! Click on the link below to activate your account:
+= edit_account_activation_url(@user.activation_token, email: @user.email)

--- a/app/views/user_mailer/password_reset.html.slim
+++ b/app/views/user_mailer/password_reset.html.slim
@@ -1,0 +1,2 @@
+h1 User#password_reset
+p = "#{@greeting}, find me in app/views/user_mailer/password_reset.html.slim"

--- a/app/views/user_mailer/password_reset.text.slim
+++ b/app/views/user_mailer/password_reset.text.slim
@@ -1,0 +1,3 @@
+' User#password_reset
+= "\r\n" * 2
+' #{@greeting}, find me in app/views/user_mailer/password_reset.text.slim

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,8 +27,11 @@ Rails.application.configure do
   end
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :test
+  host = 'localhost' # ここをコピペすると失敗します。自分の環境に合わせてください。
+  config.action_mailer.default_url_options = { host: host, protocol: 'http' }
+  
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
   post   '/login',   to: 'sessions#create'
   delete '/logout',  to: 'sessions#destroy'
   resources :users
+  resources :account_activations, only: [:edit]
 end

--- a/db/migrate/20220405095854_add_activation_to_users.rb
+++ b/db/migrate/20220405095854_add_activation_to_users.rb
@@ -1,0 +1,7 @@
+class AddActivationToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :activation_digest, :string
+    add_column :users, :activated, :boolean, default: false
+    add_column :users, :activated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220404071531) do
+ActiveRecord::Schema.define(version: 20220405095854) do
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
@@ -20,6 +20,9 @@ ActiveRecord::Schema.define(version: 20220404071531) do
     t.string "password_digest"
     t.string "remember_digest"
     t.boolean "admin", default: false
+    t.string "activation_digest"
+    t.boolean "activated", default: false
+    t.datetime "activated_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,9 @@ User.create!(name:  "Example User",
              email: "example@railstutorial.org",
              password:              "foobar",
              password_confirmation: "foobar",
-             admin: true)
+             admin: true,
+             activated: true,
+             activated_at: Time.zone.now)
 
 99.times do |n|
   name  = Faker::Name.name
@@ -11,5 +13,7 @@ User.create!(name:  "Example User",
   User.create!(name:  name,
                email: email,
                password:              password,
-               password_confirmation: password)
+               password_confirmation: password,
+               activated: true,
+               activated_at: Time.zone.now)
 end

--- a/spec/fixtures/user_mailer/account_activation
+++ b/spec/fixtures/user_mailer/account_activation
@@ -1,0 +1,3 @@
+UserMailer#account_activation
+
+Hi, find me in app/views/user_mailer/account_activation

--- a/spec/fixtures/user_mailer/password_reset
+++ b/spec/fixtures/user_mailer/password_reset
@@ -1,0 +1,3 @@
+UserMailer#password_reset
+
+Hi, find me in app/views/user_mailer/password_reset

--- a/spec/helpers/account_activations_helper_spec.rb
+++ b/spec/helpers/account_activations_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the AccountActivationsHelper. For example:
+#
+# describe AccountActivationsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe AccountActivationsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,14 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
+  def account_activation
+    UserMailer.account_activation
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
+  def password_reset
+    UserMailer.password_reset
+  end
+
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe UserMailer, type: :mailer do
+  describe "account_activation" do
+    let(:mail) { UserMailer.account_activation }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Account activation")
+      expect(mail.to).to eq(["to@example.org"])
+      expect(mail.from).to eq(["from@example.com"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Hi")
+    end
+  end
+
+  describe "password_reset" do
+    let(:mail) { UserMailer.password_reset }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Password reset")
+      expect(mail.to).to eq(["to@example.org"])
+      expect(mail.from).to eq(["from@example.com"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Hi")
+    end
+  end
+
+end

--- a/spec/requests/account_activations_spec.rb
+++ b/spec/requests/account_activations_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "AccountActivations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,25 +3,39 @@ michael:
   email: michael@example.com
   password_digest: <%= User.digest('password') %>
   admin: true
+  activated: true
+  activated_at: <%= Time.zone.now.to_s(:db) %>
 
 archer:
   name: Sterling Archer
   email: duchess@example.gov
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now.to_s(:db) %>
+
 
 lana:
   name: Lana Kane
   email: hands@example.gov
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now.to_s(:db) %>
+
 
 malory:
   name: Malory Archer
   email: boss@example.gov
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now.to_s(:db) %>
+
 
 <% 30.times do |n| %>
 user_<%= n %>:
   name:  <%= "User #{n}" %>
   email: <%= "user-#{n}@example.com" %>
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= Time.zone.now.to_s(:db) %>
+
 <% end %>

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,16 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
+  def account_activation
+    user = User.first
+    user.activation_token = User.new_token
+    UserMailer.account_activation(user)
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
+  def password_reset
+    UserMailer.password_reset
+  end
+
+end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,14 +1,14 @@
-# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+# Preview all emails at http://localhost/rails/mailers/user_mailer
 class UserMailerPreview < ActionMailer::Preview
 
-  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
+  # Preview this email at http://localhost/rails/mailers/user_mailer/account_activation
   def account_activation
     user = User.first
     user.activation_token = User.new_token
     UserMailer.account_activation(user)
   end
 
-  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
+  # Preview this email at http://localhost/rails/mailers/user_mailer/password_reset
   def password_reset
     UserMailer.password_reset
   end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class UserMailerTest < ActionMailer::TestCase
+  test "account_activation" do
+    mail = UserMailer.account_activation
+    assert_equal "Account activation", mail.subject
+    assert_equal ["to@example.org"], mail.to
+    assert_equal ["noreply@example.com"], mail.from
+    assert_match "Hi", mail.body.encoded
+  end
+
+  test "password_reset" do
+    mail = UserMailer.password_reset
+    assert_equal "Password reset", mail.subject
+    assert_equal ["to@example.org"], mail.to
+    assert_equal ["noreply@example.com"], mail.from
+    assert_match "Hi", mail.body.encoded
+  end
+
+end


### PR DESCRIPTION
Rails tutorial 11章
https://railstutorial.jp/chapters/account_activation?version=5.1#sec-activation_conclusion

該当の11.2.2送信メールのプレビューを進めているのですが、プレビューをブラウザで開こうとすると、エラーとなります。
プレビューへのURLは http://localhost/rails/mailers/user_mailer/account_activation です。
エラーは、ArgumentError in Rails::MailersController#preview wrong number of arguments (given 0, expected 1) です。
<img width="945" alt="image" src="https://user-images.githubusercontent.com/75666856/162141104-cba5965c-4d42-42f2-8e14-a45d14b1c196.png">

def account_activation(user)での引数に関する問題だとは思うのですが、調べても解決しません。
全く同じエラーに躓いている人をteratail( https://teratail.com/questions/142141 )で見つけたのですが、解決策でのコメント（DB自体もdevelopがdefaultではなく、testになっていたのが悪さしている）の意味がよく分からず解決できてません。
それ以外の対処法は`db:migrate`などはしましたが解決していません。


分かるようでしたら、教えていただきたいです。よろしくお願いいたします。